### PR TITLE
ci: Fix Travis-CI issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,14 @@ env:
 
 before_install:
   - sudo apt-get -y install sox libsox2 libsox-dev libsox-fmt-all flac lame libav-tools
+  - sudo apt-get -y install python3-setuptools
+  - sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 1
   - git clone https://github.com/quodlibet/mutagen.git /tmp/mutagen
   - cd /tmp/mutagen
   - git checkout -b release-1.42.0
   - ./setup.py build
   - sudo ./setup.py install
-  - sudo apt install gobjc++
+  - sudo apt-get -y install gobjc++
   - git clone https://github.com/wez/atomicparsley.git /tmp/atomicparsley
   - cd /tmp/atomicparsley
   - sed -i 's/AC_PROG_CXX/AC_PROG_CXX\nAC_PROG_OBJCXX/' ./configure.ac


### PR DESCRIPTION
Mutagen appears no longer to support Python 2 and instead requires Python 3.