### PR TITLE
fix: Encoding failure when converting from FLAC to ALAC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ php:
 sudo: false
 
 env:
-  - FFMPEG_BINARY=avconv
+  - FFMPEG_BINARY=ffmpeg
 
 before_install:
-  - sudo apt-get -y install sox libsox2 libsox-dev libsox-fmt-all flac lame libav-tools
+  - sudo apt-get -y install sox libsox3 libsox-dev libsox-fmt-all flac lame ffmpeg atomicparsley
   - sudo apt-get -y install python3-setuptools
   - sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 1
   - git clone https://github.com/quodlibet/mutagen.git /tmp/mutagen
@@ -19,15 +19,15 @@ before_install:
   - git checkout -b release-1.42.0
   - ./setup.py build
   - sudo ./setup.py install
-  - sudo apt-get -y install gobjc++
-  - git clone https://github.com/wez/atomicparsley.git /tmp/atomicparsley
-  - cd /tmp/atomicparsley
-  - git checkout tags/0.9.6 -B 0.9.6
-  - sed -i 's/AC_PROG_CXX/AC_PROG_CXX\nAC_PROG_OBJCXX/' ./configure.ac
-  - ./autogen.sh
-  - ./configure
-  - sudo make
-  - sudo make install
+#  - sudo apt-get -y install gobjc++
+#  - git clone https://github.com/wez/atomicparsley.git /tmp/atomicparsley
+#  - cd /tmp/atomicparsley
+#  - git checkout tags/0.9.6 -B 0.9.6
+#  - sed -i 's/AC_PROG_CXX/AC_PROG_CXX\nAC_PROG_OBJCXX/' ./configure.ac
+#  - ./autogen.sh
+#  - ./configure
+#  - sudo make
+#  - sudo make install
   - cd $TRAVIS_BUILD_DIR
 
 before_script:

--- a/src/CliCommand/FfmpegCommand.php
+++ b/src/CliCommand/FfmpegCommand.php
@@ -52,4 +52,18 @@ class FfmpegCommand extends CliCommand implements FfmpegCommandInterface
 
         return $this;
     }
+
+    public function forceVideoCodec(string $codec): FfmpegCommand
+    {
+        $this->addArgument('outfile-options', '-vcodec ' . $codec);
+
+        return $this;
+    }
+
+    public function disableVideo(): FfmpegCommand
+    {
+        $this->addArgument('outfile-options', '-vn');
+
+        return $this;
+    }
 }

--- a/src/Flac/FlacConverter.php
+++ b/src/Flac/FlacConverter.php
@@ -134,7 +134,10 @@ class FlacConverter implements
             ->input($inputFile)
             ->output($outputFile)
             ->overwriteOutput($outputFile)
-            ->forceAudioCodec('alac');
+            ->forceAudioCodec('alac')
+            // This omits any thumbnail, whereas the latter call preserves it.
+            //->disableVideo()
+            ->forceVideoCodec('copy');
 
         $this->runProcess($this->ffmpeg->compose(), $this->ffmpeg);
 

--- a/tests/CliCommand/FfmpegCommandTest.php
+++ b/tests/CliCommand/FfmpegCommandTest.php
@@ -98,4 +98,24 @@ class FfmpegCommandTest extends TestCase
             $this->ffmpegCommand->asString()
         );
     }
+
+    public function testItComposesForceVideoCodecCommandCorrectly()
+    {
+        $this->ffmpegCommand->forceVideoCodec('copy');
+
+        $this->assertEquals(
+            $this->ffmpegCommand->getBinary() . ' -vcodec copy',
+            $this->ffmpegCommand->asString()
+        );
+    }
+
+    public function testItComposesDisableVideoCommandCorrectly()
+    {
+        $this->ffmpegCommand->disableVideo('alac');
+
+        $this->assertEquals(
+            $this->ffmpegCommand->getBinary() . ' -vn',
+            $this->ffmpegCommand->asString()
+        );
+    }
 }


### PR DESCRIPTION
Modern versions of ffmpeg (tested on stock Ubuntu 20.04 LTS with ffmpeg 4.2.4) throw an exception when attempting to convert a FLAC file to ALAC when the FLAC file contains a cover image in the video stream, unless specific CLI switches are passed.

Passing "-vn" will omit the cover image altogether, whereas passing "-vcodec copy" will preserve it; failure to do one or the other results in an exception.

The latter technique is mentioned in https://unix.stackexchange.com/questions/415477/lossless-audio-conversion-from-flac-to-alac-using-ffmpeg#comment1026896_415478

It is unknown why failing to pass the aforementioned switches did not cause problems in previous versions.