### PR TITLE
ci: Remove obsoleted, manual build processes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,23 +11,7 @@ env:
   - FFMPEG_BINARY=ffmpeg
 
 before_install:
-  - sudo apt-get -y install sox libsox3 libsox-dev libsox-fmt-all flac lame ffmpeg atomicparsley
-  - sudo apt-get -y install python3-setuptools
-  - sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-  - git clone https://github.com/quodlibet/mutagen.git /tmp/mutagen
-  - cd /tmp/mutagen
-  - git checkout -b release-1.42.0
-  - ./setup.py build
-  - sudo ./setup.py install
-#  - sudo apt-get -y install gobjc++
-#  - git clone https://github.com/wez/atomicparsley.git /tmp/atomicparsley
-#  - cd /tmp/atomicparsley
-#  - git checkout tags/0.9.6 -B 0.9.6
-#  - sed -i 's/AC_PROG_CXX/AC_PROG_CXX\nAC_PROG_OBJCXX/' ./configure.ac
-#  - ./autogen.sh
-#  - ./configure
-#  - sudo make
-#  - sudo make install
+  - sudo apt-get -yq install sox libsox3 libsox-dev libsox-fmt-all flac lame ffmpeg atomicparsley python3-mutagen
   - cd $TRAVIS_BUILD_DIR
 
 before_script:


### PR DESCRIPTION
Ubuntu 20.04 LTS provides sufficiently recent versions of both Mutagen and AtomicParsley, so building them from source is no longer necessary.