### PR TITLE
fix: Improve exception messages

### DIFF
--- a/src/Alac/AlacTagVerifier.php
+++ b/src/Alac/AlacTagVerifier.php
@@ -38,14 +38,14 @@ class AlacTagVerifier implements TagVerifierInterface
                 if (!isset($tagsOnFile[$fieldName][0])) {
                     $failures[] = $fieldName.' tag does not exist on tagged file';
                 } elseif ($tagsOnFile[$fieldName][0] != $fieldValue) {
-                    $failures[] = $fieldName.' ('.$tagsOnFile[$fieldName][0].' != '.$fieldValue.')';
+                    $failures[] = 'Expected value "'. $fieldValue . '" does not match actual value "' . $tagsOnFile[$fieldName][0] . '" for tag "' . $fieldName . '")';
                 }
             }
         }
 
         if (count($failures) > 0) {
             throw new AudioTaggerException(
-                'Expected value does not match actual value for tags: '.implode(', ', $failures)
+                'Tagging failures occurred: '.implode(', ', $failures)
             );
         }
     }

--- a/src/Flac/FlacTagVerifier.php
+++ b/src/Flac/FlacTagVerifier.php
@@ -40,15 +40,17 @@ class FlacTagVerifier implements TagVerifierInterface
 
         foreach ($tagData as $fieldName => $fieldDataArray) {
             foreach ($fieldDataArray as $numericIndex => $fieldValue) {
-                if ($vorbiscomment[$fieldName][0] != $fieldValue) {
-                    $failures[] = $fieldName;
+                if (!isset($vorbiscomment[$fieldName][0])) {
+                    $failures[] = $fieldName.' tag does not exist on tagged file';
+                } else if ($vorbiscomment[$fieldName][0] != $fieldValue) {
+                    $failures[] = 'Expected value "'. $fieldValue . '" does not match actual value "' . $vorbiscomment[$fieldName][0] . '" for tag "' . $fieldName . '")';
                 }
             }
         }
 
         if (count($failures) > 0) {
             throw new AudioTaggerException(
-                'Expected value does not match actual value for tags: '.implode(', ', $failures)
+                'Tagging failures occurred: '.implode(', ', $failures)
             );
         }
     }

--- a/src/Mp3/Mp3TagVerifier.php
+++ b/src/Mp3/Mp3TagVerifier.php
@@ -46,15 +46,17 @@ class Mp3TagVerifier implements TagVerifierInterface
                     }
                 }
 
-                if ($tagsOnFile[$fieldName][0] != $fieldValue) {
-                    $failures[] = $fieldName.' ('.$tagsOnFile[$fieldName][0].' != '.$fieldValue.')';
+                if (!isset($tagsOnFile[$fieldName][0])) {
+                    $failures[] = $fieldName.' tag does not exist on tagged file';
+                } else if ($tagsOnFile[$fieldName][0] != $fieldValue) {
+                    $failures[] = 'Expected value "'. $fieldValue . '" does not match actual value "' . $tagsOnFile[$fieldName][0] . '" for tag "' . $fieldName . '")';
                 }
             }
         }
 
         if (count($failures) > 0) {
             throw new AudioTaggerException(
-                'Expected value does not match actual value for tags: '.implode(', ', $failures)
+                'Tagging failures occurred: '.implode(', ', $failures)
             );
         }
     }


### PR DESCRIPTION
When audio tagging didn't yield the expected result, the exception messages didn't provide the underlying specifics. Now, they do.