### PR TITLE
Add support for and require PHP >= 8.1

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -1,0 +1,36 @@
+name: Test Suite
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  tests:
+    name: Run Test Suite
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the repository
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Set up Docker
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v2
+
+      # Build and bring up Docker containers
+      - name: Build and start services
+        run: |
+          docker compose up --build -d
+
+      # Run tests inside the container
+      - name: Run test suite
+        run: |
+          docker compose run app vendor/bin/phpunit --testdox
+
+      # Bring down Docker containers after tests
+      - name: Tear down services
+        if: always()
+        run: docker compose down

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - master
+      - 3.x
 
 jobs:
   tests:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -28,18 +28,19 @@ jobs:
 
       # Build and bring up Docker containers
       - name: Build and start services
-        run: |
-          docker compose up --build -d
-          docker compose ps  # Show status of all containers
+        run: docker compose up --build -d
 
-      # Debug: Verify running services
-      - name: List running containers
-        run: docker ps -a
+      # Install Composer dependencies and fix Git ownership in one step
+      - name: Fix Git ownership and install Composer dependencies
+        run: |
+          docker compose run app sh -c "
+            git config --global --add safe.directory /app &&
+            composer install --prefer-dist --no-scripts --no-progress --no-interaction
+          "
 
       # Run tests inside the container
       - name: Run test suite
         run: |
-          docker compose run app composer install --prefer-dist --no-scripts --no-progress --no-interaction --dev
           docker compose run app vendor/bin/phpunit --testdox
 
       # Bring down Docker containers after tests

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -6,6 +6,7 @@ on:
       - main
       - master
       - 3.x
+    types: [opened, synchronize, reopened]
 
 jobs:
   tests:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -22,14 +22,24 @@ jobs:
       - name: Set up Docker
         uses: docker/setup-buildx-action@v2
 
+      # Debug: Check Docker version
+      - name: Verify Docker Installation
+        run: docker --version
+
       # Build and bring up Docker containers
       - name: Build and start services
         run: |
           docker compose up --build -d
+          docker compose ps  # Show status of all containers
+
+      # Debug: Verify running services
+      - name: List running containers
+        run: docker ps -a
 
       # Run tests inside the container
       - name: Run test suite
         run: |
+          docker compose run app composer install --prefer-dist --no-scripts --no-progress --no-interaction --dev
           docker compose run app vendor/bin/phpunit --testdox
 
       # Bring down Docker containers after tests

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.vagrant
 /composer.lock
 /vendor
+/.phpunit.result.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,14 +27,14 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update && apt-get install -y locales && \
-    echo "es_US.UTF-8 UTF-8" > /etc/locale.gen && \
-    locale-gen es_US.UTF-8 && \
-    update-locale LANG=es_US.UTF-8
+    echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
+    locale-gen en_US.UTF-8 && \
+    update-locale LANG=en_US.UTF-8
 
 # Set the default locale environment variables explicitly
-ENV LC_ALL=es_US.UTF-8 \
-    LANG=es_US.UTF-8 \
-    LANGUAGE=es_US.UTF-8
+ENV LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8
 
 # Install Composer
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,12 +38,3 @@ ENV LC_ALL=en_US.UTF-8 \
 
 # Install Composer
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
-
-# Copy the application files to the container
-COPY . .
-
-# Install all dependencies, including dev dependencies
-RUN composer install --prefer-dist --no-scripts --no-progress --no-interaction --dev
-
-# Run PHPUnit tests as the default command
-CMD ["vendor/bin/phpunit", "--testdox"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 COPY . .
 
 # Install all dependencies, including dev dependencies
-RUN composer install --prefer-dist --no-scripts --no-progress --no-interaction
+RUN composer install --prefer-dist --no-scripts --no-progress --no-interaction --dev
 
 # Run PHPUnit tests as the default command
 CMD ["vendor/bin/phpunit", "--testdox"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# Use an official PHP image as the base
+FROM php:8.1-cli
+
+# Set working directory inside the container
+WORKDIR /app
+
+# Install necessary dependencies and audio processing tools
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
+        locales \
+        git \
+        unzip \
+        libzip-dev \
+        zip \
+        sox \
+        libsox3 \
+        libsox-dev \
+        libsox-fmt-all \
+        flac \
+        lame \
+        ffmpeg \
+        atomicparsley \
+        python3-mutagen \
+        imagemagick && \
+    docker-php-ext-install zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y locales && \
+    echo "es_US.UTF-8 UTF-8" > /etc/locale.gen && \
+    locale-gen es_US.UTF-8 && \
+    update-locale LANG=es_US.UTF-8
+
+# Set the default locale environment variables explicitly
+ENV LC_ALL=es_US.UTF-8 \
+    LANG=es_US.UTF-8 \
+    LANGUAGE=es_US.UTF-8
+
+# Install Composer
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+# Copy the application files to the container
+COPY . .
+
+# Install all dependencies, including dev dependencies
+RUN composer install --prefer-dist --no-scripts --no-progress --no-interaction
+
+# Run PHPUnit tests as the default command
+CMD ["vendor/bin/phpunit", "--testdox"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+build:
+	docker compose build
+
+up:
+	docker compose up -d
+
+test:
+	docker compose run app composer install --prefer-dist --no-scripts --no-progress --no-interaction
+	docker compose run app vendor/bin/phpunit --testdox
+
+down:
+	docker compose down

--- a/README.md
+++ b/README.md
@@ -9,3 +9,39 @@
 ## About ##
 
 The Audio Manipulator component of the indieHD Framework for PHP.
+
+## Running Tests ##
+
+The simplest way to run the test suite is using the included `Makefile`.
+
+To build the Docker container:
+
+```shell
+make build
+```
+
+To start the Docker container:
+
+```shell
+make up
+```
+
+To run the test suite:
+
+```shell
+make test
+```
+
+To teardown the container:
+
+```shell
+make down
+```
+
+If for any reason using `make` is not an option, the commands in the `Makefile` can be run manually.
+
+To log into the container for any other reason, simply run:
+
+```
+docker compose run app bash
+```

--- a/composer.json
+++ b/composer.json
@@ -40,5 +40,10 @@
         "phpmd/phpmd": "^2.6",
         "friendsofphp/php-cs-fixer": "^3.8",
         "php-coveralls/php-coveralls": "^2.1"
+    },
+    "config": {
+        "allow-plugins": {
+            "phpro/grumphp": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0",
+        "php": ">=8.1.0",
         "symfony/process": "^6.0",
         "symfony/dependency-injection": "^6.0",
-        "james-heinrich/getid3": "dev-master#bd3501c815586f8292316f832d5ff8425f466ba0",
+        "james-heinrich/getid3": "1.9.23",
         "monolog/monolog": "^2.0",
         "league/flysystem": "^3.0",
         "vlucas/phpdotenv": "^5.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: ["vendor/bin/phpunit", "--testdox"]

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,23 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
-	<testsuites>
-		<testsuite name="Audio Manipulator Library">
-			<directory>./tests</directory>
-		</testsuite>
-	</testsuites>
-
-	<filter>
-		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">./src</directory>
-		</whitelist>
-	</filter>
-
-	<php>
-		<env name="SOX_BINARY" value="sox" force="false" />
-		<env name="METAFLAC_BINARY" value="metaflac" force="false" />
-		<env name="MID3V2_BINARY" value="mid3v2" force="false" />
-		<env name="LAME_BINARY" value="lame" force="false" />
-		<env name="FFMPEG_BINARY" value="ffmpeg" force="false" />
-		<env name="ATOMIC_PARSLEY_BINARY" value="AtomicParsley" force="false" />
-	</php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="false">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Audio Manipulator Library">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="SOX_BINARY" value="sox" force="false"/>
+    <env name="METAFLAC_BINARY" value="metaflac" force="false"/>
+    <env name="MID3V2_BINARY" value="mid3v2" force="false"/>
+    <env name="LAME_BINARY" value="lame" force="false"/>
+    <env name="FFMPEG_BINARY" value="ffmpeg" force="false"/>
+    <env name="ATOMIC_PARSLEY_BINARY" value="AtomicParsley" force="false"/>
+  </php>
 </phpunit>

--- a/src/Alac/AlacTagger.php
+++ b/src/Alac/AlacTagger.php
@@ -32,7 +32,7 @@ class AlacTagger implements TaggerInterface
 
         $this->logger->configureLogger('ALAC_TAGGER_LOG');
 
-        $this->env = ['LC_ALL' => 'en_US.utf8'];
+        $this->env = ['LC_ALL' => 'en_US.UTF-8'];
     }
 
     public function writeTags(string $file, array $tagData): void

--- a/src/Flac/FlacTagger.php
+++ b/src/Flac/FlacTagger.php
@@ -32,10 +32,10 @@ class FlacTagger implements TaggerInterface
 
         $this->logger->configureLogger('FLAC_TAGGER_LOG');
 
-        // If "['LC_ALL' => 'en_US.utf8']" is not passed here, any UTF-8
+        // If "['LC_ALL' => 'en_US.UTF-8']" is not passed here, any UTF-8
         // character will appear as a "#" symbol in the resultant tag value.
 
-        $this->env = ['LC_ALL' => 'en_US.utf8'];
+        $this->env = ['LC_ALL' => 'en_US.UTF-8'];
     }
 
     /**

--- a/src/Mp3/Mp3Tagger.php
+++ b/src/Mp3/Mp3Tagger.php
@@ -32,7 +32,7 @@ class Mp3Tagger implements TaggerInterface
 
         $this->logger->configureLogger('MP3_TAGGER_LOG');
 
-        $this->env = ['LC_ALL' => 'en_US.utf8'];
+        $this->env = ['LC_ALL' => 'en_US.UTF-8'];
     }
 
     public function writeTags(string $file, array $tagData): void


### PR DESCRIPTION
As part of this effort, I'm adding modern test tooling, primarily to enable the PHP test suite to be run locally via Docker, as well as via a GitHub workflow runner.